### PR TITLE
chore: 자바 소스 파일 추가하도록 build.gradle 수정 (#2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.4'
     id 'io.spring.dependency-management' version '1.1.4'
+
+    id 'idea'
 }
 
 group = 'com.capstone'
@@ -9,6 +11,12 @@ version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '17'
+}
+
+idea {
+    module {
+        downloadSources = true
+    }
 }
 
 configurations {


### PR DESCRIPTION
기존 build.gradle 을 로드하면 이미 컴파일된 자바 클래스 파일을 다운로드 받는다. 이러면 외부 라이브러리를 사용할 때 javadoc 과 같은 코멘트를 볼 수 없어 코드를 이해하기 어렵다. build.gradle을 로드해서 디펜던시를 추가할 때, 자바 소스 코드까지 다운로드하도록 변경했다.